### PR TITLE
Adding ignore option for final response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ The options are:
   sender : email, sender address, defaults to name@example.org
   timeout : integer, socket timeout defaults to 0 which is no timeout
   fdqn : domain, used as part of the HELO, defaults to mail.example.org
-  dns: ip address, or array of ip addresses (as strings), used to set the servers of the dns check
+  dns: ip address, or array of ip addresses (as strings), used to set the servers of the dns check,
+  ignore: set an ending response code integer to ignore, such as 450 for greylisted emails 
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports.verify = function (email, options, callback) {
   if (options && !options.sender) options.sender = "name@example.org";
   if (options && !options.timeout) options.timeout = 0;
   if (options && !options.fqdn) options.fqdn = "mail.example.org";
+  if (options && (!options.ignore || typeof options.ignore !== "number")) options.ignore = false;
 
   var validator = require('email-validator');
 
@@ -117,7 +118,7 @@ module.exports.verify = function (email, options, callback) {
                               socket.end();
                           }
                           break;
-                  case 3: if (response.indexOf('250') > -1) {
+                  case 3: if (response.indexOf('250') > -1 || (options.ignore && response.indexOf(options.ignore) > -1)) {
                               // RCPT Worked
                               success = true;
                           }


### PR DESCRIPTION
There is a final response code at the end of the email verification, sometimes you may wish to ignore this, for instance 450 is the response code for "greylisting". We've been seeing a lot of genuine ISPs greylisted.

Plus, thanks for creating a great plugin :)
