### PR TITLE
Add ability to read addresses from the plain text file (*.txt)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ logs
 pids
 *.pid
 *.seed
+
+# Text file containing address (Testing)
+*.txt

--- a/app.js
+++ b/app.js
@@ -80,6 +80,16 @@ for (var i = 0 ; i < arguments.length ; i++) {
   else if (domain) {
     addresses.push(arguments[i] + domain);
   }
+  else if (arguments[i] === '-file' && arguments[i+1]){
+    require('./methods/readfromfile.js')
+      .getAddressFromTextFile(arguments[i+1])
+      .forEach(function (val, index, array) {
+        console.log(val);
+        addresses.push(val);
+      });
+    break; // immediately exit to prevent adding the filename itself to the addresses vars
+  }
+
   else {
     addresses.push(arguments[i]);
   }

--- a/app.js
+++ b/app.js
@@ -84,7 +84,6 @@ for (var i = 0 ; i < arguments.length ; i++) {
     require('./methods/readfromfile.js')
       .getAddressFromTextFile(arguments[i+1])
       .forEach(function (val, index, array) {
-        console.log(val);
         addresses.push(val);
       });
     break; // immediately exit to prevent adding the filename itself to the addresses vars

--- a/app.js
+++ b/app.js
@@ -80,7 +80,7 @@ for (var i = 0 ; i < arguments.length ; i++) {
   else if (domain) {
     addresses.push(arguments[i] + domain);
   }
-  else if (arguments[i] === '-file'){
+  else if (arguments[i] === '-file' || arguments[i] === '--file'){
     // check arguments filename supplied?
     if (!arguments[i+1]) {
       throw new Error("You must supplied the path to the file.");

--- a/app.js
+++ b/app.js
@@ -80,13 +80,18 @@ for (var i = 0 ; i < arguments.length ; i++) {
   else if (domain) {
     addresses.push(arguments[i] + domain);
   }
-  else if (arguments[i] === '-file' && arguments[i+1]){
-    require('./methods/readfromfile.js')
-      .getAddressFromTextFile(arguments[i+1])
-      .forEach(function (val, index, array) {
-        addresses.push(val);
-      });
-    break; // immediately exit to prevent adding the filename itself to the addresses vars
+  else if (arguments[i] === '-file'){
+    // check arguments filename supplied?
+    if (!arguments[i+1]) {
+      throw new Error("You must supplied the path to the file.");
+    } else {
+      require('./methods/readfromfile.js')
+        .getAddressFromTextFile(arguments[i+1])
+        .forEach(function (val, index, array) {
+          addresses.push(val);
+        });
+      break; // immediately exit to prevent adding the filename itself to the addresses vars
+    }
   }
 
   else {

--- a/methods/readfromfile.js
+++ b/methods/readfromfile.js
@@ -4,6 +4,6 @@ var _ = require('lodash');
 module.exports.getAddressFromTextFile = function(filepath) {
   var fileContent = fs.readFileSync(filepath, 'utf-8');
   var addressList = fileContent.split("\n");
-  var addressFiltered = _.without(addressList,'');
+  var addressesFiltered = _.without(addressList,'');
   return addressesFiltered;
 }

--- a/methods/readfromfile.js
+++ b/methods/readfromfile.js
@@ -2,8 +2,25 @@ var fs = require('fs');
 var _ = require('lodash');
 
 module.exports.getAddressFromTextFile = function(filepath) {
-  var fileContent = fs.readFileSync(filepath, 'utf-8');
-  var addressList = fileContent.split("\n");
-  var addressesFiltered = _.without(addressList,'');
-  return addressesFiltered;
+  var isExist = true;
+  try {
+    var fileContent = fs.readFileSync(filepath, 'utf-8');
+  } catch (e){
+    if (e.code === 'ENOENT') console.log('File not found!');
+    else console.log('Another error: ', e);
+    isExist = false;
+  }
+  finally {
+
+    // if file is not found, do not run this!
+    if (!isExist) {
+      throw new Error("SOMETHING BROKE")
+    } else {
+      var addressList = fileContent.split("\n");
+      var addressesFiltered = _.without(addressList,'');
+      return addressesFiltered;
+    };
+  }
 }
+
+// TODO: Clean up, if posible

--- a/methods/readfromfile.js
+++ b/methods/readfromfile.js
@@ -2,34 +2,29 @@ var fs = require('fs');
 var _ = require('lodash');
 
 module.exports.getAddressFromTextFile = function(filepath) {
-  var file = { isExist: true, extension: '' };
+  var file = { exist: true, extension: '' };
 
-  file.isExist = true;
+  file.exist = true;
   file.extension = require('path').extname(filepath);
-
-    console.log("extension: ", file.extension);
-    if (file.extension === '.txt')  console.log('It\'s text');
-    else console.log('it\'s not text');
-
-    // forced throw error, check extension
-    throw new Error('forced throw error, check extension');
 
   try {
     var fileContent = fs.readFileSync(filepath, 'utf-8');
   } catch (e) {
     if (e.code === 'ENOENT') console.log('File not found!');
     else console.log('Error: ', e);
-    file.isExist = false;
+    file.exist = false;
   } finally {
-    if (!file.isExist) {
+
+    if (!file.exist || e.code === 'ENOENT') {
       // if file is not found, do not run this!
-      throw new Error("SOMETHING BROKE")
+      console.log('Error, File not found!');
     } else {
       var addressList = fileContent.split("\n");
       var addressesFiltered = _.without(addressList,'');
       return addressesFiltered;
-    };
+    }
+
   }
 }
 
-// TODO: Clean up, remove forced throw error.
+// TODO: Check again

--- a/methods/readfromfile.js
+++ b/methods/readfromfile.js
@@ -2,8 +2,8 @@ var fs = require('fs');
 var _ = require('lodash');
 
 module.exports.getAddressFromTextFile = function(filepath) {
-  var addressesString = fs.readFileSync(filepath, 'utf-8');
-  var addressesList = addressesString.split("\n");
-  var addressesFiltered = _.without(addressesList,'');
+  var fileContent = fs.readFileSync(filepath, 'utf-8');
+  var addressList = fileContent.split("\n");
+  var addressFiltered = _.without(addressList,'');
   return addressesFiltered;
 }

--- a/methods/readfromfile.js
+++ b/methods/readfromfile.js
@@ -2,18 +2,27 @@ var fs = require('fs');
 var _ = require('lodash');
 
 module.exports.getAddressFromTextFile = function(filepath) {
-  var isExist = true;
+  var file = { isExist: true, extension: '' };
+
+  file.isExist = true;
+  file.extension = require('path').extname(filepath);
+
+    console.log("extension: ", file.extension);
+    if (file.extension === '.txt')  console.log('It\'s text');
+    else console.log('it\'s not text');
+
+    // forced throw error, check extension
+    throw new Error('forced throw error, check extension');
+
   try {
     var fileContent = fs.readFileSync(filepath, 'utf-8');
-  } catch (e){
+  } catch (e) {
     if (e.code === 'ENOENT') console.log('File not found!');
-    else console.log('Another error: ', e);
-    isExist = false;
-  }
-  finally {
-
-    // if file is not found, do not run this!
-    if (!isExist) {
+    else console.log('Error: ', e);
+    file.isExist = false;
+  } finally {
+    if (!file.isExist) {
+      // if file is not found, do not run this!
       throw new Error("SOMETHING BROKE")
     } else {
       var addressList = fileContent.split("\n");
@@ -23,4 +32,4 @@ module.exports.getAddressFromTextFile = function(filepath) {
   }
 }
 
-// TODO: Clean up, if posible
+// TODO: Clean up, remove forced throw error.

--- a/methods/readfromfile.js
+++ b/methods/readfromfile.js
@@ -3,9 +3,13 @@ var _ = require('lodash');
 
 module.exports.getAddressFromTextFile = function(filepath) {
   var file = { exist: true, extension: '' };
+  var extensionErrorMsg = "Sorry, you needed to put addresses list into plain text (*.txt) file." +
+                          " Separated each address by new line";
 
   file.exist = true;
   file.extension = require('path').extname(filepath);
+
+  if (file.extension !== '.txt') throw new Error(extensionErrorMsg);
 
   try {
     var fileContent = fs.readFileSync(filepath, 'utf-8');
@@ -15,8 +19,7 @@ module.exports.getAddressFromTextFile = function(filepath) {
     file.exist = false;
   } finally {
 
-    if (!file.exist || e.code === 'ENOENT') {
-      // if file is not found, do not run this!
+    if (!file.exist) {
       console.log('Error, File not found!');
     } else {
       var addressList = fileContent.split("\n");
@@ -26,5 +29,3 @@ module.exports.getAddressFromTextFile = function(filepath) {
 
   }
 }
-
-// TODO: Check again

--- a/methods/readfromfile.js
+++ b/methods/readfromfile.js
@@ -1,0 +1,9 @@
+var fs = require('fs');
+var _ = require('lodash');
+
+module.exports.getAddressFromTextFile = function(filepath) {
+  var addressesString = fs.readFileSync(filepath, 'utf-8');
+  var addressesList = addressesString.split("\n");
+  var addressesFiltered = _.without(addressesList,'');
+  return addressesFiltered;
+}


### PR DESCRIPTION
Added an ability to read address from the plain text file. Currently is accepting only *.txt file with each address per line. I setup two flags that will make it read from file, `--file` and `-file` (since I saw `-f` was already in used). 

Example: `email-verify --file (addresses_plain_text_file)`

The verifying flow typically the same. It will find a text file that was supplied into the command. Reading  addresses in the text file. Put it in an array. Then iterates on each one and verifying each address.
