### PR TITLE
Returning tryagain as a parameter for the email verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,35 @@ This module has tests with Mocha. Run `npm test` and make sure you have a solid 
 
 Use (also see the app.js file):
 
-```
+```javascript
 var verifier = require('email-verify');
+var infoCodes = verifier.infoCodes;
+
 verifier.verify( 'anemail@domain.com', function( err, info ){
   if( err ) console.log(err);
   else{
     console.log( "Success (T/F): " + info.success );
     console.log( "Info: " + info.info );
+    
+    //Info object returns a code which representing a state of validation:
+    
+    //Connected to SMTP server and finished email verification
+    console.log(info.code === infoCodes.finishedVerification);
+    
+    //Domain not found
+    console.log(info.code === infoCodes.domainNotFound);
+    
+    //Email is not valid
+    console.log(info.code === infoCodes.invalidEmailStructure);
+    
+    //No MX record in domain name
+    console.log(info.code === infoCodes.noMxRecords);
+    
+    //SMTP connection timeout
+    console.log(info.code === infoCodes.SMTPConnectionTimeout);
+    
+    //SMTP connection error
+    console.log(info.code === infoCodes.SMTPConnectionError)
   }
 });
 ```

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ function beginSMTPQueries(params){
 
   if( params.options.timeout > 0 ){
     socket.setTimeout(params.options.timeout,() => {
-      callback(null,{ success: false, info: 'Connection Timed Out', addr: params.email, code: infoCodes.SMTPConnectionTimeout })
+      callback(null,{ success: false, info: 'Connection Timed Out', addr: params.email, code: infoCodes.SMTPConnectionTimeout, tryagain:tryagain })
       socket.destroy()
     })
   }
@@ -229,11 +229,11 @@ function beginSMTPQueries(params){
 
   socket.on('error', function(err) {
     logger.error("Connection error")
-    callback( err, { success: false, info: 'SMTP connection error', addr: params.email, code: infoCodes.SMTPConnectionError })
+    callback( err, { success: false, info: 'SMTP connection error', addr: params.email, code: infoCodes.SMTPConnectionError, tryagain:tryagain })
   })
 
   socket.on('end', function() {
     logger.info("Closing connection")
-    callback(null, { success: success, info: (params.email + ' is ' + (success ? 'a valid' : 'an invalid') + ' address'), addr: params.email, code: infoCodes.finishedVerification })
+    callback(null, { success: success, info: (params.email + ' is ' + (success ? 'a valid' : 'an invalid') + ' address'), addr: params.email, code: infoCodes.finishedVerification, tryagain:tryagain })
   })
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,44 +1,59 @@
-var assert = require('assert')
+const assert = require('assert')
+
 
 describe('email-verify', function() {
-  this.timeout(5000);
+  this.timeout(20000);
 
-  var verifier = require('../index.js');
+  const verifier = require('../index.js');
+  const verifyCodes = verifier.verifyCodes;
 
   describe('#verify()', function() {
     it('existing email: should respond with an object where success is true', function(done){
-      verifier.verify('rob@below.io', function (err, info) {
+      verifier.verify('support@github.com', function (err, info) {
         assert(info.success);
+        assert(info.code === verifyCodes.finishedVerification);
+        done();
+      });
+    });
+    it('non-existing domain: should respond with an object where success is false', function(done){
+      verifier.verify('admin@klklklklkklklklkl.com', function (err, info) {
+        assert(!info.success);
+        assert(info.code === verifyCodes.domainNotFound);
         done();
       });
     });
     it('non-existing email: should respond with an object where success is false', function(done){
-      verifier.verify('antirob@below.io', function (err, info) {
-        assert(!info.success);
-        done();
+      verifier.verify('admin@github.com', function (err, info) {
+          assert(!info.success);
+          assert(info.code === verifyCodes.finishedVerification);
+          done();
       });
     });
     it('badly formed email: should respond with an object where success is false', function(done){
       verifier.verify('badlyformed##email@email@.com', function (err, info) {
         assert(!info.success);
+        assert(info.code === verifyCodes.invalidEmailStructure);
         done();
       });
     });
     it('short timeout: should respond with an object where success is false', function (done) {
-      verifier.verify('rob@below.io', { timeout: 1, port: 25 }, function (err, info) {
+      verifier.verify('support@github.com', { timeout: 1, port: 25 }, function (err, info) {
         assert(!info.success);
+        assert(info.code === verifyCodes.SMTPConnectionTimeout);
         done();
       });
     });
     it('long timeout: should respond with an object where success is true', function (done) {
-      verifier.verify('rob@below.io', { timeout: 5000, port: 25 }, function (err, info) {
+      verifier.verify('support@github.com', { timeout: 5000, port: 25 }, function (err, info) {
         assert(info.success);
+        assert(info.code === verifyCodes.finishedVerification);
         done();
       });
     });
     it('bad smtp port: should respond with an object where success is false', function(done) {
-      verifier.verify('rob@below.io', { port: 600 }, function (err, info) {
+      verifier.verify('admin@github.com', { timeout: 5000, port: 6464}, function (err, info) {
         assert(!info.success);
+        assert(info.code === verifyCodes.SMTPConnectionTimeout);
         done();
       });
     });


### PR DESCRIPTION
I saw tryagain unused, this is very valueable to a user if they want to try to verify the email address again. This value should be returned as part of the data. I added it in.