### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#SMTP Email Verification
+# SMTP Email Verification
 
-###Install
+### Install
 
 ```
 npm install -g email-verify
@@ -10,7 +10,7 @@ npm install -g email-verify
 
 If you upgrade to > 0.0.12 from a previous version, you will need to make minor changes in your code. The callback was made to be error first.
 
-###Usage
+### Usage
 You can use it stand alone with the email-verify command and as many email addresses as you want to check.
 
 ```
@@ -51,7 +51,7 @@ The FDQN is used on the first HELO of the SMTP protocol. Defaults for the sender
 
 The module has one asynchronous method: verify( email, _options_, callback )
 
-###Callback
+### Callback
 The callback is a function(err, info) that has an info object:
 ```
 {
@@ -61,7 +61,7 @@ The callback is a function(err, info) that has an info object:
 }
 ```
 
-###Options
+### Options
 The options are:
 ```
 {
@@ -74,7 +74,7 @@ The options are:
 }
 ```
 
-###Flow
+### Flow
 
 The basic flow is as follows:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
