### PR TITLE
Use strict for node 5.5

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+'use strict';
+
 let Promise = require('bluebird'),
     verify = Promise.promisify(require('./index.js').verify),
     argv = process.argv.slice(2),

--- a/methods/readfromfile.js
+++ b/methods/readfromfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let fs = require('fs')
 
 module.exports.getAddressFromTextFile = function(filepath) {


### PR DESCRIPTION
After running a clean install, using the email-verify CLI results in an error:
```
/Users/<user>/.nvm/versions/node/v5.5.0/lib/node_modules/email-verify/app.js:3
let Promise = require('bluebird'),
^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:139:18)
    at node.js:999:3
```
This can be fixed by adding `'use strict';` to the top of the file. This will not change the behavior of the program.
