### PR TITLE
new option - `smtpTimeout`. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ function beginSMTPQueries(params){
     if (tm) {
       clearTimeout(tm)
     }
-    callback( err, { success: false, info: 'SMTP connection error', addr: params.email, code: infoCodes.SMTPConnectionError })
+    callback( err, { success: false, info: 'SMTP connection error', addr: params.email, code: infoCodes.SMTPConnectionError, tryagain:tryagain })
   })
 
   socket.once('end', function() {
@@ -256,6 +256,6 @@ function beginSMTPQueries(params){
     if (tm) {
       clearTimeout(tm)
     }
-    callback(null, { success: success, info: (params.email + ' is ' + (success ? 'a valid' : 'an invalid') + ' address'), addr: params.email, code: infoCodes.finishedVerification, banner:banner })
+    callback(null, { success: success, info: (params.email + ' is ' + (success ? 'a valid' : 'an invalid') + ' address'), addr: params.email, code: infoCodes.finishedVerification, tryagain:tryagain, banner:banner })
   })
 }


### PR DESCRIPTION
30 seconds. It allows to deal with MX servers tarpiting us -https://en.wikipedia.org/wiki/Tarpit_(networking).
As result of tarpiting, SMTP VRFY check can take realy long time.
This option finishes it after 30 second