### PR TITLE
Updating nyc library due to several vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "mocha": "^4.0.1",
-    "nyc": "^11.3.0",
+    "nyc": "^15.1.0",
     "validator": "^9.1.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
The current version of nyc library used by email-verify currently contains several vulnerabilities.
This PR updates the library to the latest version which fixes it.